### PR TITLE
plumb the polling of Cloudant metrics into the Prometheus output

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ export CLOUDANT_APIKEY="my_IAM_API_KEY"
 ## Running
 
 ```sh
-go run cloudant.com/prometheus/main.go 
+go run cmd/couchmonitor/main.go 
 ```

--- a/cmd/couchmonitor/main.go
+++ b/cmd/couchmonitor/main.go
@@ -1,11 +1,10 @@
 package main
 
 import (
-	"encoding/json"
 	"flag"
-	"fmt"
 	"log"
 	"net/http"
+
 	// "regexp"
 	"time"
 
@@ -22,33 +21,6 @@ import (
 
 var addr = flag.String("listen-address", ":8080", "The address to listen on for HTTP requests.")
 
-// poll the Cloudant replication scheduler every 5 seconds
-func Collect(service *cloudantv1.CloudantV1) {
-
-	// nicked from https://gobyexample.com/tickers
-	ticker := time.NewTicker(5000 * time.Millisecond)
-	done := make(chan bool)
-
-	go func() {
-		for {
-			select {
-			case <-done:
-				return
-			case t := <-ticker.C:
-				fmt.Println("Polling Cloudant replication", t)
-
-				// fetch scheduler status
-				getSchedulerDocsOptions := service.NewGetSchedulerDocsOptions()
-				schedulerDocsResult, _, _ := service.GetSchedulerDocs(getSchedulerDocsOptions)
-				b, _ := json.MarshalIndent(schedulerDocsResult, "", "  ")
-
-				// to stdout - not plumbed into Prometheus client yet
-				fmt.Println(string(b))
-			}
-		}
-	}()
-}
-
 // entry point
 func main() {
 	log.Println("Hello, World!")
@@ -59,13 +31,10 @@ func main() {
 			ServiceName: "CLOUDANT",
 		})
 
-	// collectors - pass in the Cloudant service
-
-	Collect(service)
-
 	// Create a new registry.
 	reg := prometheus.NewRegistry()
 
+	// set up the replication collector to poll every 5s
 	rc := monitors.ReplicationCollector{
 		Reg:      reg,
 		Cldt:     service,
@@ -73,12 +42,6 @@ func main() {
 		Done:     make(chan bool),
 	}
 	rc.Go()
-
-	// Add Go module build info.
-	// reg.MustRegister(collectors.NewBuildInfoCollector())
-	// reg.MustRegister(collectors.NewGoCollector(
-	// 	collectors.WithGoCollectorRuntimeMetrics(collectors.GoRuntimeMetricsRule{Matcher: regexp.MustCompile("/.*")}),
-	// ))
 
 	// Expose the registered metrics via HTTP.
 	http.Handle("/metrics", promhttp.HandlerFor(
@@ -88,6 +51,5 @@ func main() {
 			EnableOpenMetrics: true,
 		},
 	))
-	log.Println("Hello world from new Go Collector!")
 	log.Fatal(http.ListenAndServe(*addr, nil))
 }

--- a/internal/monitors/replication.go
+++ b/internal/monitors/replication.go
@@ -38,8 +38,10 @@ func (rc *ReplicationCollector) Go() {
 				schedulerDocsResult, _, _ := rc.Cldt.GetSchedulerDocs(getSchedulerDocsOptions)
 
 				// to stdout - not plumbed into Prometheus client yet
-				log.Printf("docs written %d", *schedulerDocsResult.Docs[0].Info.DocsWritten)
-				docsProcessed.Set(float64(*schedulerDocsResult.Docs[0].Info.DocsWritten))
+				if len(schedulerDocsResult.Docs) > 0 {
+					log.Printf("docs written %d", *schedulerDocsResult.Docs[0].Info.DocsWritten)
+					docsProcessed.Set(float64(*schedulerDocsResult.Docs[0].Info.DocsWritten))
+				}
 			}
 		}
 	}()

--- a/internal/monitors/replication.go
+++ b/internal/monitors/replication.go
@@ -16,8 +16,9 @@ type ReplicationCollector struct {
 }
 
 func (rc *ReplicationCollector) Go() {
-	docsProcessed := prometheus.NewCounter(prometheus.CounterOpts{
+	docsProcessed := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "replication_docs_processed_total",
+		Help: "The number of documents writtent ot the target",
 	})
 	rc.Reg.MustRegister(docsProcessed)
 
@@ -30,7 +31,15 @@ func (rc *ReplicationCollector) Go() {
 				return
 			case t := <-ticker.C:
 				log.Println("Tick at", t)
-				docsProcessed.Inc()
+				log.Println("Polling Cloudant replication", t)
+
+				// fetch scheduler status
+				getSchedulerDocsOptions := rc.Cldt.NewGetSchedulerDocsOptions()
+				schedulerDocsResult, _, _ := rc.Cldt.GetSchedulerDocs(getSchedulerDocsOptions)
+
+				// to stdout - not plumbed into Prometheus client yet
+				log.Printf("docs written %d", *schedulerDocsResult.Docs[0].Info.DocsWritten)
+				docsProcessed.Set(float64(*schedulerDocsResult.Docs[0].Info.DocsWritten))
 			}
 		}
 	}()


### PR DESCRIPTION
- changed the metric to a "gauge" because the counter could only be incremented by a known value
- put the Cloudant poller in the right place


to do

- we need to output one metric per replication
- this code only cares about the 0th replication
- need to label each output so that we know which line is which