### PR TITLE
Use Builder Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,18 +11,15 @@ COPY . .
 RUN go mod download
  
 # Builds your app with optional configuration
-RUN go build  ./cmd/couchmonitor
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build  ./cmd/couchmonitor
  
 ############################
 # STEP 2 build a small image
 ############################
-FROM scratch
+FROM alpine
 
 # Copy our static executable.
 COPY --from=builder /app/couchmonitor /
-
-# Tells Docker which network port your container listens on
-EXPOSE 8080
  
 # Specifies the executable command that runs when the container starts
 CMD [ "/couchmonitor", "--listen-address", "0.0.0.0:8080"]


### PR DESCRIPTION
The dockerfile now builds the executable and then copies it into a more minimal image based on alpine. I had to add some compiler flags to make it work, based on this SO answer: https://stackoverflow.com/questions/55106186/no-such-file-or-directory-with-docker-scratch-image.

Also I couldn't get it to work with the "scratch" base image, which is smaller than alpine, but doesn't include CA certs so HTTPS traffic to IAM or Cloudant fails. Alpine seems to include these.


