### PR TITLE
Use counter-type metrics for replications

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,12 @@ go 1.19
 
 require (
 	github.com/IBM/cloudant-go-sdk v0.4.1
+	github.com/IBM/go-sdk-core/v5 v5.13.2
 	github.com/prometheus/client_golang v1.15.1
+	github.com/prometheus/client_model v0.3.0
 )
 
 require (
-	github.com/IBM/go-sdk-core/v5 v5.13.2 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
@@ -24,7 +25,6 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
-	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.42.0 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect
 	go.mongodb.org/mongo-driver v1.11.6 // indirect

--- a/internal/monitors/replication.go
+++ b/internal/monitors/replication.go
@@ -7,7 +7,6 @@ import (
 	"cloudant.com/couchmonitor/internal/utils"
 	"github.com/IBM/cloudant-go-sdk/cloudantv1"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 type ReplicationMonitor struct {
@@ -17,37 +16,37 @@ type ReplicationMonitor struct {
 }
 
 var (
-	changesPendingTotal = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	changesPendingTotal = utils.AutoNewSettableCounterVec(prometheus.Opts{
 		Name: "cloudant_replication_changes_pending_total",
 		Help: "The number of changes remaining to process (approximately)",
 	},
 		[]string{"docid"},
 	)
-	docWriteFailuresTotal = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	docWriteFailuresTotal = utils.AutoNewSettableCounterVec(prometheus.Opts{
 		Name: "cloudant_replication_doc_write_failures_total",
 		Help: "The number of failures writing documents to the target",
 	},
 		[]string{"docid"},
 	)
-	docsReadTotal = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	docsReadTotal = utils.AutoNewSettableCounterVec(prometheus.Opts{
 		Name: "cloudant_replication_docs_read_total",
 		Help: "Total number of documents read from the source database",
 	},
 		[]string{"docid"},
 	)
-	docsWrittenTotal = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	docsWrittenTotal = utils.AutoNewSettableCounterVec(prometheus.Opts{
 		Name: "cloudant_replication_docs_written_total",
 		Help: "Total number of documents written to the target database",
 	},
 		[]string{"docid"},
 	)
-	missingRevsFoundTotal = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	missingRevsFoundTotal = utils.AutoNewSettableCounterVec(prometheus.Opts{
 		Name: "cloudant_replication_missing_revs_found_total",
 		Help: "Total number of revs found so far on the source that are not at the target",
 	},
 		[]string{"docid"},
 	)
-	revsCheckedTotal = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	revsCheckedTotal = utils.AutoNewSettableCounterVec(prometheus.Opts{
 		Name: "cloudant_replication_revs_checked_total",
 		Help: "Total number of revs processed on the source",
 	},

--- a/internal/utils/counter.go
+++ b/internal/utils/counter.go
@@ -1,0 +1,149 @@
+package utils
+
+import (
+	"sort"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"google.golang.org/protobuf/proto"
+)
+
+// LabelPairSorter implements sort.Interface. It is used to sort a slice of
+// dto.LabelPair pointers.
+// Copied from "github.com/prometheus/client_golang/prometheus"
+type LabelPairSorter []*dto.LabelPair
+
+func (s LabelPairSorter) Len() int {
+	return len(s)
+}
+
+func (s LabelPairSorter) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s LabelPairSorter) Less(i, j int) bool {
+	return s[i].GetName() < s[j].GetName()
+}
+
+// SettableCounter implements a Prometheus counter-type metric
+// that can be directly set by a uesr, in contrast to the builtin
+// prometheus.Counter which can only be incremented.
+//
+// This allows us to more effectively "proxy" the counter type
+// metrics that we receive from CouchDB, otherwise we have to
+// use a prometheus.Gauge, which doesn't give good affordances
+// within Prometheus itself, eg, calculating rates.
+type SettableCounter struct {
+	val float64
+
+	desc       *prometheus.Desc
+	labelPairs []*dto.LabelPair
+
+	now func() time.Time // To mock out time.Now() for testing.
+}
+
+// NewSettableCounter returns a new SettableCounter.
+func NewSettableCounter(opts prometheus.Opts) *SettableCounter {
+	desc := prometheus.NewDesc(
+		prometheus.BuildFQName(opts.Namespace, opts.Subsystem, opts.Name),
+		opts.Help,
+		nil,
+		opts.ConstLabels,
+	)
+
+	// Taken from NewDesc implementation
+	constLabelPairs := make([]*dto.LabelPair, 0, len(opts.ConstLabels))
+	for n, v := range opts.ConstLabels {
+		constLabelPairs = append(constLabelPairs, &dto.LabelPair{
+			Name:  proto.String(n),
+			Value: proto.String(v),
+		})
+	}
+	sort.Sort(LabelPairSorter(constLabelPairs))
+
+	return &SettableCounter{
+		desc:       desc,
+		labelPairs: constLabelPairs,
+		now:        time.Now,
+	}
+}
+
+// Describe implements prometheus.Collector.
+func (c *SettableCounter) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.desc
+}
+
+// Collect implements prometheus.Collector.
+func (c *SettableCounter) Collect(ch chan<- prometheus.Metric) {
+	ch <- c
+}
+
+// Desc implements prometheus.Metric
+func (c *SettableCounter) Desc() *prometheus.Desc {
+	return c.desc
+}
+
+// Write implements prometheus.Metric
+func (c *SettableCounter) Write(out *dto.Metric) error {
+	out.Label = c.labelPairs
+	out.Counter = &dto.Counter{Value: proto.Float64(c.val), Exemplar: nil}
+	return nil
+}
+
+// Set directly sets the counter to v.
+func (c *SettableCounter) Set(v float64) {
+	c.val = v
+}
+
+// SettableCounterVec creates a metric vector containing SettableCounter.
+type SettableCounterVec struct {
+	*prometheus.MetricVec
+}
+
+// NewSettableCounterVec creates a new SettableCounterVec.
+func NewSettableCounterVec(opts prometheus.Opts, labelNames []string) *SettableCounterVec {
+	desc := prometheus.V2.NewDesc(
+		prometheus.BuildFQName(opts.Namespace, opts.Subsystem, opts.Name),
+		opts.Help,
+		prometheus.UnconstrainedLabels(labelNames),
+		opts.ConstLabels,
+	)
+	return &SettableCounterVec{
+		MetricVec: prometheus.NewMetricVec(desc, func(lvs ...string) prometheus.Metric {
+			return &SettableCounter{
+				desc:       desc,
+				labelPairs: prometheus.MakeLabelPairs(desc, lvs),
+				now:        time.Now,
+			}
+		}),
+	}
+}
+
+// AutoNewSettableCounterVec creates and MustRegisters() a new SettableCounterVec.
+func AutoNewSettableCounterVec(opts prometheus.Opts, labelNames []string) *SettableCounterVec {
+	v := NewSettableCounterVec(opts, labelNames)
+	prometheus.DefaultRegisterer.MustRegister(v)
+	return v
+}
+
+func (v *SettableCounterVec) GetMetricWithLabelValues(lvs ...string) (*SettableCounter, error) {
+	metric, err := v.MetricVec.GetMetricWithLabelValues(lvs...)
+	if metric != nil {
+		return metric.(*SettableCounter), err
+	}
+	return nil, err
+}
+
+// WithLabelValues works as GetMetricWithLabelValues, but panics where
+// GetMetricWithLabelValues would have returned an error. Not returning an
+// error allows shortcuts like
+//
+//	myVec.WithLabelValues("404", "GET").Add(42)
+func (v *SettableCounterVec) WithLabelValues(lvs ...string) *SettableCounter {
+	c, err := v.GetMetricWithLabelValues(lvs...)
+	if err != nil {
+		panic(err)
+	}
+	return c
+}


### PR DESCRIPTION
We add a new Prometheus metric, a counter-type metric that can have its value set directly. This is in contrast to the Go prometheus client's Counter, which can only be incremented (and is heavily optimised to that use-case).

We do this because the metrics we get from CouchDB are already counters. With the prometheus client builtins, we can only use a Gauge if we want to set the value directly. However, the gauge-type metrics don't offer the same affordances in the Prometheus UX --- for example, a counter-type metric can more easily be worked into a rate over time graph, and rollovers to zero (eg on CouchDB restarts) are better handled.

Therefore we want to emit as a counter-type but be able to directly set the counter value from the counter we're getting from CouchDB. The most natural way to do that I could see was to create a simple custom metric type that allowed setting the value. It's pretty simple in the end because we want to do very little and we don't care about performance very much, alongside the fact that we can leverage a lot of functionality that already exists in the prometheus client library, like MetricVec to manage all the metrics we create via dynamic labels.