### PR TITLE
Replication status

### DIFF
--- a/cmd/cloudant_exporter/main.go
+++ b/cmd/cloudant_exporter/main.go
@@ -46,11 +46,21 @@ func main() {
 	rc := monitorLooper{
 		Interval: 5 * time.Second,
 		FailBox:  utils.NewFailBox(failAfter),
-		Chk:      &monitors.ReplicationMonitor{Cldt: cldt},
+		Chk:      &monitors.ReplicationProgressMonitor{Cldt: cldt},
 	}
 	go func() {
 		rc.Go()
-		monitorFailed <- "ReplicationMonitor"
+		monitorFailed <- "ReplicationProgressMonitor"
+	}()
+
+	rs := monitorLooper{
+		Interval: 10 * time.Minute,
+		FailBox:  utils.NewFailBox(failAfter),
+		Chk:      &monitors.ReplicationStatusMonitor{Cldt: cldt},
+	}
+	go func() {
+		rs.Go()
+		monitorFailed <- "ReplicationStatusMonitor"
 	}()
 
 	tm := monitorLooper{

--- a/internal/monitors/activetasks.go
+++ b/internal/monitors/activetasks.go
@@ -2,7 +2,6 @@ package monitors
 
 import (
 	"log"
-	"time"
 
 	"cloudant.com/cloudant_exporter/internal/utils"
 	"github.com/IBM/cloudant-go-sdk/cloudantv1"
@@ -11,9 +10,7 @@ import (
 )
 
 type ActiveTasksMonitor struct {
-	Cldt     *cloudantv1.CloudantV1
-	Interval time.Duration
-	FailBox  *utils.FailBox
+	Cldt *cloudantv1.CloudantV1
 }
 
 var (

--- a/internal/monitors/replicationprogress.go
+++ b/internal/monitors/replicationprogress.go
@@ -10,7 +10,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-type ReplicationMonitor struct {
+type ReplicationProgressMonitor struct {
 	Cldt     *cloudantv1.CloudantV1
 	Interval time.Duration
 	FailBox  *utils.FailBox
@@ -60,11 +60,11 @@ var (
 	)
 )
 
-func (rc *ReplicationMonitor) Name() string {
-	return "ReplicationMonitor"
+func (rc *ReplicationProgressMonitor) Name() string {
+	return "ReplicationProgressMonitor"
 }
 
-func (rc *ReplicationMonitor) Retrieve() error {
+func (rc *ReplicationProgressMonitor) Retrieve() error {
 	// fetch scheduler status
 	getSchedulerDocsOptions := rc.Cldt.NewGetSchedulerDocsOptions()
 	getSchedulerDocsOptions.SetLimit(50)
@@ -75,7 +75,7 @@ func (rc *ReplicationMonitor) Retrieve() error {
 		return err
 	}
 	for _, d := range schedulerDocsResult.Docs {
-		log.Printf("[ReplicationMonitor] Replication %q: docs written %d", *d.DocID, *d.Info.DocsWritten)
+		log.Printf("[ReplicationProgressMonitor] Replication %q: docs written %d", *d.DocID, *d.Info.DocsWritten)
 		if d.Info.ChangesPending != nil {
 			changesPendingTotal.WithLabelValues(*d.DocID).Set(float64(*d.Info.ChangesPending))
 		}

--- a/internal/monitors/replicationprogress.go
+++ b/internal/monitors/replicationprogress.go
@@ -2,7 +2,6 @@ package monitors
 
 import (
 	"log"
-	"time"
 
 	"cloudant.com/cloudant_exporter/internal/utils"
 	"github.com/IBM/cloudant-go-sdk/cloudantv1"
@@ -11,9 +10,7 @@ import (
 )
 
 type ReplicationProgressMonitor struct {
-	Cldt     *cloudantv1.CloudantV1
-	Interval time.Duration
-	FailBox  *utils.FailBox
+	Cldt *cloudantv1.CloudantV1
 }
 
 var (

--- a/internal/monitors/replicationstatus.go
+++ b/internal/monitors/replicationstatus.go
@@ -4,16 +4,13 @@ import (
 	"log"
 	"time"
 
-	"cloudant.com/cloudant_exporter/internal/utils"
 	"github.com/IBM/cloudant-go-sdk/cloudantv1"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 type ReplicationStatusMonitor struct {
-	Cldt     *cloudantv1.CloudantV1
-	Interval time.Duration
-	FailBox  *utils.FailBox
+	Cldt *cloudantv1.CloudantV1
 }
 
 var (

--- a/internal/monitors/replicationstatus.go
+++ b/internal/monitors/replicationstatus.go
@@ -1,0 +1,77 @@
+package monitors
+
+import (
+	"log"
+	"time"
+
+	"cloudant.com/cloudant_exporter/internal/utils"
+	"github.com/IBM/cloudant-go-sdk/cloudantv1"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type ReplicationStatusMonitor struct {
+	Cldt     *cloudantv1.CloudantV1
+	Interval time.Duration
+	FailBox  *utils.FailBox
+}
+
+var (
+	replicatonStatus = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "cloudant_replication_status_count",
+			Help: "Current replication count by status",
+		},
+		[]string{"status"},
+	)
+)
+
+func (rc *ReplicationStatusMonitor) Name() string {
+	return "ReplicationStatusMonitor"
+}
+
+func (rc *ReplicationStatusMonitor) Retrieve() error {
+	var skip int = 0
+	var batchSize int = 100
+	var iterations = 0
+	getSchedulerDocsOptions := rc.Cldt.NewGetSchedulerDocsOptions()
+	getSchedulerDocsOptions.SetLimit(int64(batchSize))
+	statusCounts := map[string]uint{
+		"initializing": 0,
+		"error":        0,
+		"pending":      0,
+		"running":      0,
+		"crashing":     0,
+		"completed":    0,
+		"failed":       0,
+	}
+
+	// repeat until we get a smaller batch than we asked for
+	for {
+		// fetch scheduler jobs
+		getSchedulerDocsOptions.SetSkip(int64(skip))
+
+		schedulerJobsResult, _, err := rc.Cldt.GetSchedulerDocs(getSchedulerDocsOptions)
+		if err != nil {
+			return err
+		}
+		for _, d := range schedulerJobsResult.Docs {
+			statusCounts[*d.State]++
+		}
+		skip += len(schedulerJobsResult.Docs)
+		iterations++
+		if len(schedulerJobsResult.Docs) < batchSize || iterations == 10 {
+			break
+		} else {
+			time.Sleep(5 * time.Second)
+		}
+	}
+
+	// output one metric per replication status
+	for key, val := range statusCounts {
+		log.Printf("[ReplicationProgressMonitor] %s %d", key, val)
+		replicatonStatus.WithLabelValues(key).Set(float64(val))
+	}
+
+	return nil
+}

--- a/internal/monitors/throughput.go
+++ b/internal/monitors/throughput.go
@@ -3,9 +3,7 @@ package monitors
 import (
 	"context"
 	"encoding/json"
-	"time"
 
-	"cloudant.com/cloudant_exporter/internal/utils"
 	"github.com/IBM/cloudant-go-sdk/cloudantv1"
 	"github.com/IBM/cloudant-go-sdk/common"
 	"github.com/IBM/go-sdk-core/v5/core"
@@ -14,9 +12,7 @@ import (
 )
 
 type ThroughputMonitor struct {
-	Cldt     *cloudantv1.CloudantV1
-	Interval time.Duration
-	FailBox  *utils.FailBox
+	Cldt *cloudantv1.CloudantV1
 }
 
 var (


### PR DESCRIPTION
Polls the `_scheduler/jobs` every 10 minutes, paging through all the results (with a 5s delay between each call). 

Outputs a new metric per job: 

```
# HELP cloudant_replication_status Current status per replication
# TYPE cloudant_replication_status gauge
cloudant_replication_status{docid="a3",source="https://sub.cloudant.com/a/",status="started",target="https://sub.cloudant.com/aa3/"} 0
```

Closes https://github.com/glynnbird/promgo/issues/6