### PR TITLE
tweak monitor startup behaviour

### DIFF
--- a/cmd/cloudant_exporter/main.go
+++ b/cmd/cloudant_exporter/main.go
@@ -136,7 +136,7 @@ func (rc *monitorLooper) Go() {
 
 	// do the first poll straight after a random pause, and at
 	// regular intervals thereafter
-	offset := rand.Intn(15)
+	offset := rand.Intn(15) //nolint:gosec,gomnd // math/rand is good enough for this use-case
 	time.Sleep(time.Duration(offset * int(time.Second)))
 	log.Printf("[%s] startup tick (+%d s)", rc.Chk.Name(), offset)
 	err := rc.Chk.Retrieve()

--- a/cmd/cloudant_exporter/main.go
+++ b/cmd/cloudant_exporter/main.go
@@ -132,8 +132,6 @@ type monitorLooper struct {
 }
 
 func (rc *monitorLooper) Go() {
-	ticker := time.NewTicker(rc.Interval)
-
 	// do the first poll straight after a random pause, and at
 	// regular intervals thereafter
 	offset := rand.Intn(15) //nolint:gosec,gomnd // math/rand is good enough for this use-case
@@ -147,6 +145,7 @@ func (rc *monitorLooper) Go() {
 		rc.FailBox.Success()
 	}
 
+	ticker := time.NewTicker(rc.Interval)
 	for range ticker.C {
 		log.Printf("[%s] tick", rc.Chk.Name())
 		err := rc.Chk.Retrieve()

--- a/cmd/cloudant_exporter/main.go
+++ b/cmd/cloudant_exporter/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"math/rand"
 	"net/http"
 	"runtime"
 	"time"
@@ -132,6 +133,19 @@ type monitorLooper struct {
 
 func (rc *monitorLooper) Go() {
 	ticker := time.NewTicker(rc.Interval)
+
+	// do the first poll straight after a random pause, and at
+	// regular intervals thereafter
+	offset := rand.Intn(15)
+	time.Sleep(time.Duration(offset * int(time.Second)))
+	log.Printf("[%s] startup tick (+%d s)", rc.Chk.Name(), offset)
+	err := rc.Chk.Retrieve()
+	if err != nil {
+		log.Printf("[%s] error getting tasks: %v; last success: %s", rc.Chk.Name(), err, rc.FailBox.LastSuccess())
+		rc.FailBox.Failure()
+	} else {
+		rc.FailBox.Success()
+	}
 
 	for range ticker.C {
 		log.Printf("[%s] tick", rc.Chk.Name())


### PR DESCRIPTION
- Each monitor triggers once before the ticker kicks in, to avoid a long delay before any requests are made.
- but a random delay is applied before each monitor triggers to avoid a burst of traffic at startup.